### PR TITLE
add a utility for differencing bufr files (bufrdif.py)

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,8 @@
+since version 1.0.0
+===================
+* added difbufr.py utility.
+* ncepbufr.open table kwarg can be an existing ncepbufr.open instance.
+
 version 1.0.0
 =============
 * add function for computing bit flags from integer and mnemonic

--- a/Changelog
+++ b/Changelog
@@ -1,7 +1,9 @@
 since version 1.0.0
 ===================
-* added difbufr.py utility.
+* added bufrdif.py utility.
 * ncepbufr.open table kwarg can be an existing ncepbufr.open instance.
+* ncepbufr.openmsg now has msg_receipt_time kwarg (YYYYMMDDHHMM).
+* added bufrsubset.py (subset bufr file by receipt time).
 
 version 1.0.0
 =============

--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,5 @@
-since version 1.0.0
-===================
+version 1.1.0
+=============
 * added bufrdif.py utility.
 * ncepbufr.open table kwarg can be an existing ncepbufr.open instance.
 * ncepbufr.openmsg now has msg_receipt_time kwarg (YYYYMMDDHHMM).

--- a/ncepbufr/__init__.py
+++ b/ncepbufr/__init__.py
@@ -4,7 +4,7 @@ import bisect
 import numpy as np
 from .bufr_mnemonics import *
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 __bufrlib_version__ = _bufrlib.bvers().rstrip()
 
 # create list of allowed fortran unit numbers

--- a/ncepbufr/__init__.py
+++ b/ncepbufr/__init__.py
@@ -41,6 +41,7 @@ class open:
         """
         # randomly choose available fortran unit number
         self.lunit = random.choice(_funits)
+        self.filename = filename
         '''bufr file opened with this fortran unit number'''
         _funits.remove(self.lunit)
         if not _funits:

--- a/ncepbufr/__init__.py
+++ b/ncepbufr/__init__.py
@@ -319,7 +319,7 @@ class open:
         to `ncepbufr.open.checkpoint`.
         """
         _bufrlib.rewnbf(self.lunit,1)
-    def open_message(self,msg_type,msg_date):
+    def open_message(self,msg_type,msg_date,msg_receipt_time=None):
         """
         open new bufr message.
 
@@ -330,7 +330,20 @@ class open:
         `msg_date`: reference date (e.g. `YYYYMMDDHH`) for message. The
         number of digits in the reference date is controlled by
         `ncepbufr.open.set_datelength`, and is 10 by default.
+
+        `msg_receipt_time` bufr tank receipt time YYYYMMDDHHMM (optional).
         """
+        if msg_receipt_time is not None:
+            yyyymmddhhmm = str(msg_receipt_time)
+            try:
+                yyyy = int(yyyymmddhhmm[0:4])
+                mm = int(yyyymmddhhmm[4:6])
+                dd = int(yyyymmddhhmm[6:8])
+                hh = int(yyyymmddhhmm[8:10])
+                mm = int(yyyymmddhhmm[10:12])
+                _bufrlib.strcpt('Y',yyyy,mm,dd,hh,mm)
+            except IndexError:
+                pass # don't write receipt time
         _bufrlib.openmg(self.lunit,msg_type,int(msg_date))
     def close_message(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ ext_bufrlib = Extension(name  = '_bufrlib',
 
 if __name__ == "__main__":
     setup(name = 'py-ncepbufr',
-          version           = "1.0.0",
+          version           = "1.1.0",
           description       = "Python interface to NCEP bufrlib",
           author            = "Jeff Whitaker",
           author_email      = "jeffrey.s.whitaker@noaa.gov",

--- a/test/inventory.py
+++ b/test/inventory.py
@@ -5,7 +5,11 @@ import sys
 # print inventory of specified bufr file
 
 bufr = ncepbufr.open(sys.argv[1])
-for n,msg in enumerate(bufr.inventory()):
+nsubsets = 0
+inv = bufr.inventory()
+for n,msg in enumerate(inv):
     out = (n+1,)+msg
     print('message %s: %s %s %s %s subsets' % out)
+    nsubsets += out[4]
 bufr.close()
+print('%s total subsets in %s messages' % (nsubsets,len(inv)))

--- a/utils/bufrdif.py
+++ b/utils/bufrdif.py
@@ -81,13 +81,10 @@ for bkey in bufr_dict2:
 print('%s unique message subsets (out of %s) in bufr 2' % (ncount,len(bufr_dict2)))
 
 # write unique messages in bufr 2 to new file
-# dump prepbufr table from input file.
-tablefile = tempfile.mktemp()
-bufr.dump_table(tablefile)
 # open output bufr file using same prepbufr table.
 print('creating %s' % filename_out)
-bufrout = ncepbufr.open(filename_out,'w',tablefile)
 bufr.rewind()
+bufrout = ncepbufr.open(filename_out,'w',bufr)
 while bufr.advance() == 0: 
     if bufr.msg_counter in uniq_messages: # this message has a unique subset
         bufrout.open_message(bufr.msg_type,bufr.msg_date) # open output message
@@ -100,4 +97,3 @@ while bufr.advance() == 0:
 
 # close up shop.
 bufr.close(); bufrout.close()
-os.remove(tablefile)

--- a/utils/bufrdif.py
+++ b/utils/bufrdif.py
@@ -1,0 +1,103 @@
+"""bufrdif.py - read in two bufr files, write out a third containing data
+that is unique in the 2nd file
+
+version 0.1: Jeff Whitaker 20190227
+"""
+from __future__ import print_function
+import ncepbufr, sys, os, tempfile, hashlib
+
+if len(sys.argv) < 5:
+    msg = """python prepbufrdif.py <bufr 1> <bufr 2> <bufr2-bufr1> <bufr_type>
+where <bufr 1> is input bufr file (early cutoff)
+      <bufr 2> is input bufr file (late cutoff)
+      <bufr2-bufr1> is output bufr file containing obs in 2 not in 1
+      <bufr_type> is type of bufr file ('prep','satwnd')\n"""
+    raise SystemExit(msg)
+filename_in1 = sys.argv[1]
+filename_in2 = sys.argv[2]
+filename_out = sys.argv[3]
+bufr_type = sys.argv[4]
+if filename_out == filename_in1 or filename_out == filename_in2:
+    msg="output file must not have same name as input files"
+    raise SystemExit(msg)
+
+verbose = False # controls level of output
+
+if bufr_type == 'prep':
+    hdstr='SID XOB YOB DHR TYP ELV T29'
+    obstr='POB QOB TOB UOB VOB PMO PRSS PWO'
+    qcstr='PQM QQM TQM WQM PMQ PWQ'
+elif bufr_type == 'satwnd':
+    hdstr = 'SAID CLAT CLON CLATH CLONH YEAR MNTH DAYS HOUR MINU SWCM SAZA SCCF SWQM'
+    obstr = 'EHAM HAMD PRLC WDIR WSPD'
+    qcstr = 'OGCE GNAP PCCF'
+else:
+    msg="unrecognized bufr_type, must be one of 'prep','satwnd'"
+    raise SystemExit(msg)
+
+def get_bufr_dict(bufr,verbose=False):
+    bufr_dict = {}
+    ndup = 0
+    while bufr.advance() == 0: 
+        nsubset = 0
+        while bufr.load_subset() == 0: # loop over subsets in message.
+            hdrhash = hash(bufr.read_subset(hdstr).tostring())
+            obshash = hash(bufr.read_subset(obstr).tostring())
+            qchash = hash(bufr.read_subset(qcstr).tostring())
+            key = '%s %s %s %s' % (bufr.msg_type,hdrhash,obshash,qchash)
+            key = hashlib.md5(key).hexdigest()
+            nsubset += 1
+            if key in bufr_dict:
+                ndup += 1
+                if verbose: print('warning: duplicate key for msg type %s' % bufr.msg_type)
+            else:
+                bufr_dict[key] = bufr.msg_counter,nsubset
+    return bufr_dict,ndup
+
+# create dictionaries with md5 hashes for each message as keys, 
+# (msg number,subset number) tuple as values.
+bufr = ncepbufr.open(filename_in1)
+bufr_dict1,ndup = get_bufr_dict(bufr,verbose=verbose)
+print('%s duplicate keys found in %s' % (ndup,filename_in1))
+bufr.close()
+
+bufr = ncepbufr.open(filename_in2)
+bufr_dict2,ndup = get_bufr_dict(bufr,verbose=verbose)
+print('%s duplicate keys found in %s' % (ndup,filename_in2))
+
+# find message subsets in bufr 2 that aren't in bufr 1
+# uniq_messages is a dict whose keys are message numbers.
+# dict entry is a list with unique subset numbers.
+ncount = 0; uniq_messages = {}
+for bkey in bufr_dict2:
+    if bkey not in bufr_dict1:
+        ncount += 1
+        nmsg, nsubset = bufr_dict2[bkey]
+        if nmsg in uniq_messages:
+           uniq_messages[nmsg].append(nsubset)
+        else:
+           uniq_messages[nmsg] = [nsubset]
+        if verbose: print('msg/subset %s/%s in bufr 2 not in bufr 1' % (nmsg,nsubset))
+print('%s unique message subsets in bufr 2' % ncount)
+
+# write unique messages in bufr 2 to new file
+# dump prepbufr table from input file.
+tablefile = tempfile.mktemp()
+bufr.dump_table(tablefile)
+# open output bufr file using same prepbufr table.
+print('creating %s' % filename_out)
+bufrout = ncepbufr.open(filename_out,'w',tablefile)
+bufr.rewind()
+while bufr.advance() == 0: 
+    if bufr.msg_counter in uniq_messages: # this message has a unique subset
+        bufrout.open_message(bufr.msg_type,bufr.msg_date) # open output message
+        nsubset = 0
+        while bufr.load_subset() == 0: # loop over subsets in message.
+            nsubset += 1 
+            if nsubset in uniq_messages[bufr.msg_counter]: # write unique subsets
+                bufrout.copy_subset(bufr)
+        bufrout.close_message() # close message
+
+# close up shop.
+bufr.close(); bufrout.close()
+os.remove(tablefile)

--- a/utils/bufrdif.py
+++ b/utils/bufrdif.py
@@ -63,6 +63,7 @@ def get_bufr_dict(bufr,verbose=False,bufr_type='prep'):
             if bufr_type == 'prep':
                 secs = int(hdr[3]*3600.)
                 obdate = refdate + secs*delta
+                # 4th element in header must be DHR (obs time - cycle time in hours) !!
                 hdr[3]=float(obdate.strftime('%Y%m%d%H%M%S')) # YYYYMMDDHHMMSS
             hdrhash = hash(hdr.tostring())
             obshash = hash(bufr.read_subset(obstr).tostring())

--- a/utils/bufrdif.py
+++ b/utils/bufrdif.py
@@ -77,8 +77,8 @@ for bkey in bufr_dict2:
            uniq_messages[nmsg].append(nsubset)
         else:
            uniq_messages[nmsg] = [nsubset]
-        if verbose: print('msg/subset %s/%s in bufr 2 not in bufr 1' % (nmsg,nsubset))
-print('%s unique message subsets (out of %s) in bufr 2' % (ncount,len(bufr_dict2)))
+        if verbose: print('msg/subset %s/%s in %s not in %s' % (nmsg,nsubset,filename_in2,filename_in1))
+print('%s unique message subsets (out of %s) in %s' % (ncount,len(bufr_dict2),filename_in2))
 
 # write unique messages in bufr 2 to new file
 # open output bufr file using same prepbufr table.

--- a/utils/bufrdif.py
+++ b/utils/bufrdif.py
@@ -78,7 +78,7 @@ for bkey in bufr_dict2:
         else:
            uniq_messages[nmsg] = [nsubset]
         if verbose: print('msg/subset %s/%s in bufr 2 not in bufr 1' % (nmsg,nsubset))
-print('%s unique message subsets in bufr 2' % ncount)
+print('%s unique message subsets (out of %s) in bufr 2' % (ncount,len(bufr_dict2)))
 
 # write unique messages in bufr 2 to new file
 # dump prepbufr table from input file.

--- a/utils/bufrsubset.py
+++ b/utils/bufrsubset.py
@@ -1,0 +1,49 @@
+"""bufrsubset.py - read in a bufr files, write out a subset of bufr data 
+with receipt time later than specified time.
+
+version 0.1: Jeff Whitaker 20190305
+"""
+from __future__ import print_function
+import ncepbufr, sys, os, tempfile, hashlib, argparse
+from datetime import datetime, timedelta
+
+# Parse command line args
+ap = argparse.ArgumentParser()
+ap.add_argument("input_bufr", help="path to input BUFR file")
+ap.add_argument("receipt_time", help="threshold receipt time (YYYYMMDDHHMM)")
+ap.add_argument("output_bufr", help="output BUFR file")
+ap.add_argument('--verbose', '-v', action='store_true')
+
+MyArgs = ap.parse_args()
+
+filename_in = MyArgs.input_bufr
+filename_out = MyArgs.output_bufr
+receipt_time = int(MyArgs.receipt_time)
+verbose=MyArgs.verbose
+print("""input_bufr=%s 
+receipt_time=%s
+output_bufr=%s""" % (filename_in,receipt_time,filename_out))
+
+if filename_out == filename_in:
+    msg="output file must not have same name as input file"
+    raise SystemExit(msg)
+
+bufr = ncepbufr.open(filename_in)
+print('creating %s' % filename_out)
+bufrout = ncepbufr.open(filename_out,'w',bufr)
+
+ncount = 0; nskip = 0
+while bufr.advance() == 0: 
+    if bufr.receipt_time > 0 and bufr.receipt_time > receipt_time:
+        if verbose: print('writing message with receipt time %s (> %s)' % (bufr.receipt_time,receipt_time))
+        bufrout.open_message(bufr.msg_type,bufr.msg_date,bufr.receipt_time) # open output message
+        ncount += 1
+        while bufr.load_subset() == 0: # loop over subsets in message.
+            bufrout.copy_subset(bufr)
+        bufrout.close_message() # close message
+    else:
+        nskip += 1
+
+print('%s messages copied, %s messages skipped' % (ncount,nskip))
+# close up shop.
+bufr.close(); bufrout.close()

--- a/utils/bufrsubset.py
+++ b/utils/bufrsubset.py
@@ -1,5 +1,5 @@
-"""bufrsubset.py - read in a bufr files, write out a subset of bufr data 
-with receipt time later than specified time.
+"""bufrsubset.py - read in a bufr file, copy a subset of bufr data 
+with receipt time later than specified time to a new file.
 
 version 0.1: Jeff Whitaker 20190305
 """

--- a/utils/bufrsubset.py
+++ b/utils/bufrsubset.py
@@ -4,8 +4,7 @@ with receipt time later than specified time.
 version 0.1: Jeff Whitaker 20190305
 """
 from __future__ import print_function
-import ncepbufr, sys, os, tempfile, hashlib, argparse
-from datetime import datetime, timedelta
+import ncepbufr, sys, argparse
 
 # Parse command line args
 ap = argparse.ArgumentParser()


### PR DESCRIPTION
bufrdif.py reads in bufr1 and bufr2, writes out data to bufr3 that is in bufr2 and not bufr1.
useful for extracting new data from bufr files that are created from overlapping windows.

bufrsubset.py copies a subset of messages from an input file that have a receipt_time later than YYYYMMDDHHMM specified.

ncepbufr.open now accepts a table argument for mode='r'.  The table argument can be either an bufr table text file, or an exisiting ncepbufr.open instance.  In the latter case, the bufr table embedded in the ncepbufr.open instance is shared.

ncepbufr.openmsg now accepts a 'msg_receipt_time' kwarg.