### PR TITLE
check for lowercase env vars fix for issue #28

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you change the fortran compiler, you may have to add the
 flags `config_fc --fcompiler=<compiler name>` when setup.py is run
 (see docs for [numpy.distutils](https://docs.scipy.org/doc/numpy/f2py/distutils.html)).
 If you have built and installed the bufr library from https://github.com/JCSDA/BUFRLIB, 
-you can set the `BUFRLIB_ROOT` environment variable to point to where you installed it, and
+you can set the `bufrlib_ROOT` environment variable to point to where you installed it, and
 setup.py should use this one instead of building the library from the included source.
 However, you have to make sure that cmake (when building bufrlib) and numpy.distutils (when building 
 the python extension) are using the same fortran compiler.  Since numpy.distutils uses gfortran by

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,13 @@ from numpy.distutils.core  import setup, Extension
 import os, sys, subprocess
 
 # build fortran library if it does not yet exist.
-bufrdir = os.environ.get('BUFRLIB_ROOT') # check BUFRLIB_ROOT first
+bufrdir = os.environ.get('bufrlib_ROOT') # check bufrlib_ROOT/BUFRLIB_ROOT first
 if not bufrdir:
-    bufrdir = os.environ.get('BUFRLIB_PATH') # fall back on BUFRLIB_PATH
+    bufrdir = os.environ.get('BUFRLIB_ROOT')
+if not bufrdir:
+    bufrdir = os.environ.get('bufrlib_PATH') # fall back on bufrlib_PATH/BUFRLIB_PATH
+    if not bufrdir:
+        bufrdir = os.environ.get('BUFRLIB_PATH')
 if bufrdir:
     bufrlibdir = os.path.join(bufrdir,'lib')
     bufrincdir = os.path.join(bufrdir,'include')

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from numpy.distutils.core  import setup, Extension
 import os, sys, subprocess
 
-# build fortran library if it does not yet exist.
+# check env vars for path to pre-build bufr lib
 bufrdir = os.environ.get('bufrlib_ROOT') # check bufrlib_ROOT/BUFRLIB_ROOT first
 if not bufrdir:
     bufrdir = os.environ.get('BUFRLIB_ROOT')
@@ -9,6 +9,7 @@ if not bufrdir:
     bufrdir = os.environ.get('bufrlib_PATH') # fall back on bufrlib_PATH/BUFRLIB_PATH
     if not bufrdir:
         bufrdir = os.environ.get('BUFRLIB_PATH')
+# if path to bufr lib not specified by env var, build from source
 if bufrdir:
     bufrlibdir = os.path.join(bufrdir,'lib')
     bufrincdir = os.path.join(bufrdir,'include')


### PR DESCRIPTION
setup.py now looks for bufrlib_PATH, and if not found checks for BUFRLIB_PATH